### PR TITLE
Update react dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Vincent Lecrubier <vincent.lecrubier@gmail.com> (http://www.vincentlecrubier.fr/)",
   "license": "MIT",
   "dependencies": {
-    "react": "^0.14.7",
+    "react": "^15.3.0",
     "uuid": "^2.0.1",
     "vis": "^3.12.0"
   }


### PR DESCRIPTION
Current npm published react-graph-vis does not work:
```
TypeError: Cannot read property '__reactAutoBindMap' of undefined
    at Constructor (http://localhost:3615/dist/front/index.js:81254:16)
    at http://localhost:3615/dist/front/index.js:15330:17
    at measureLifeCyclePerf (http://localhost:3615/dist/front/index.js:15099:13)
    at ReactCompositeComponentWrapper._constructComponentWithoutOwner (http://localhost:3615/dist/front/index.js:15329:15)
    at ReactCompositeComponentWrapper._constructComponent (http://localhost:3615/dist/front/index.js:15304:22)
    at ReactCompositeComponentWrapper.mountComponent (http://localhost:3615/dist/front/index.js:15212:22)
    at Object.mountComponent (http://localhost:3615/dist/front/index.js:7755:36)
    at ReactDOMComponent.mountChildren (http://localhost:3615/dist/front/index.js:14418:45)
    at ReactDOMComponent._createInitialChildren (http://localhost:3615/dist/front/index.js:11436:33)
    at ReactDOMComponent.mountComponent (http://localhost:3615/dist/front/index.js:11261:13)
```

Credit to @stephaniefenton for making the change.