### PR TITLE
Using prop-types instead of React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.4",
+    "prop-types": "^15.5.10",
     "uuid": "^2.0.1",
     "vis": "^4.18.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import isEqual from 'lodash/isEqual';
 import differenceWith from 'lodash/differenceWith';
 import vis from 'vis';
 import uuid from 'uuid';
+import PropTypes from 'prop-types';
 
 class Graph extends Component {
   constructor(props) {
@@ -137,8 +138,12 @@ class Graph extends Component {
 
 Graph.defaultProps = {
   graph: {},
-  getNetwork: React.PropTypes.function,
   style: { width: '640px', height: '480px' }
+};
+Graph.propTypes = {
+  graph: PropTypes.object,
+  style: PropTypes.object,
+  getNetwork: PropTypes.func
 };
 
 export default Graph;


### PR DESCRIPTION
React.PropTypes has been deprecated from React v15.5. It is suggested to use 'prop-types' module: https://facebook.github.io/react/docs/typechecking-with-proptypes.html