### PR TITLE
Added function for getting nodes instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,8 @@ Graph.defaultProps = {
 Graph.propTypes = {
   graph: PropTypes.object,
   style: PropTypes.object,
-  getNetwork: PropTypes.func
+  getNetwork: PropTypes.func,
+  getNodes: PropTypes.func,
 };
 
 export default Graph;

--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,10 @@ class Graph extends Component {
     if (this.props.getNetwork) {
       this.props.getNetwork(this.Network)
     }
+    
+    if (this.props.getNodes) {
+      this.props.getNodes(this.nodes)
+    }
 
     // Add user provied events to network
     let events = this.props.events || {};


### PR DESCRIPTION
As said in #14, I Couldn't find any way to get the details about the node selected using just the events. Events just returns the node id and is not very useful. I've added a way to get the nodes instance from back to the parent component which in turn can be used to get the node information. 

Here how to use it.
In your component functions add this.
```
  setNodes = nodes => {
    this.setState({nodes});
  }
```
Your `selectNode` function
```
  selectNode = event => {
    const { nodes } = event;
    const nodeItem = this.state.nodes.get(nodes[0]);
    console.log(nodeItem);
  }
```
Calling `selectNode` from the events
```
    const events ={
      select: this.selectNode,
    };
```

Hope this helps :)
