### PR TITLE
Added ability to access Edges Dataset in parent component

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,8 @@ var Graph = function (_Component) {
       if (edgesChange) {
         var edgesRemoved = (0, _differenceWith2.default)(this.props.graph.edges, nextProps.graph.edges, _isEqual2.default);
         var edgesAdded = (0, _differenceWith2.default)(nextProps.graph.edges, this.props.graph.edges, _isEqual2.default);
-        this.patchEdges({ edgesRemoved: edgesRemoved, edgesAdded: edgesAdded });
+        var edgesChanged = (0, _differenceWith2.default)((0, _differenceWith2.default)(nextProps.graph.edges, this.props.graph.edges, _isEqual2.default), edgesAdded);
+        this.patchEdges({ edgesRemoved: edgesRemoved, edgesAdded: edgesAdded, edgesChanged : edgesChanged });
       }
 
       if (optionsChange) {
@@ -160,9 +161,11 @@ var Graph = function (_Component) {
     value: function patchEdges(_ref) {
       var edgesRemoved = _ref.edgesRemoved,
           edgesAdded = _ref.edgesAdded;
+          edgesChanged = _ref.edgesChanged;
 
       this.edges.remove(edgesRemoved);
       this.edges.add(edgesAdded);
+      this.edges.update(edgesChanged);
     }
   }, {
     key: "patchNodes",
@@ -211,6 +214,10 @@ var Graph = function (_Component) {
 
       if (this.props.getNodes) {
         this.props.getNodes(this.nodes);
+      }
+
+      if (this.props.getEdges) {
+        this.props.getEdges(this.edges);
       }
 
       // Add user provied events to network
@@ -264,7 +271,8 @@ Graph.propTypes = {
   graph: _propTypes2.default.object,
   style: _propTypes2.default.object,
   getNetwork: _propTypes2.default.func,
-  getNodes: _propTypes2.default.func
+  getNodes: _propTypes2.default.func,
+  getEdges: _propTypes2.default.func,
 };
 
 exports.default = Graph;

--- a/src/index.js
+++ b/src/index.js
@@ -156,7 +156,7 @@ Graph.propTypes = {
   style: PropTypes.object,
   getNetwork: PropTypes.func,
   getNodes: PropTypes.func,
-  getEdges: PropTyes.func,  
+  getEdges: PropTypes.func,  
 };
 
 export default Graph;

--- a/src/index.js
+++ b/src/index.js
@@ -1,278 +1,162 @@
-"use strict";
+import React, { Component } from "react";
+import defaultsDeep from "lodash/fp/defaultsDeep";
+import isEqual from "lodash/isEqual";
+import differenceWith from "lodash/differenceWith";
+import vis from "vis";
+import uuid from "uuid";
+import PropTypes from "prop-types";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
-var _react = require("react");
-
-var _react2 = _interopRequireDefault(_react);
-
-var _defaultsDeep = require("lodash/fp/defaultsDeep");
-
-var _defaultsDeep2 = _interopRequireDefault(_defaultsDeep);
-
-var _isEqual = require("lodash/isEqual");
-
-var _isEqual2 = _interopRequireDefault(_isEqual);
-
-var _differenceWith = require("lodash/differenceWith");
-
-var _differenceWith2 = _interopRequireDefault(_differenceWith);
-
-var _vis = require("vis");
-
-var _vis2 = _interopRequireDefault(_vis);
-
-var _uuid = require("uuid");
-
-var _uuid2 = _interopRequireDefault(_uuid);
-
-var _propTypes = require("prop-types");
-
-var _propTypes2 = _interopRequireDefault(_propTypes);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-var Graph = function (_Component) {
-  _inherits(Graph, _Component);
-
-  function Graph(props) {
-    _classCallCheck(this, Graph);
-
-    var _this = _possibleConstructorReturn(this, (Graph.__proto__ || Object.getPrototypeOf(Graph)).call(this, props));
-
-    var identifier = props.identifier;
-
-    _this.updateGraph = _this.updateGraph.bind(_this);
-    _this.state = {
-      identifier: identifier !== undefined ? identifier : _uuid2.default.v4()
+class Graph extends Component {
+  constructor(props) {
+    super(props);
+    const { identifier } = props;
+    this.updateGraph = this.updateGraph.bind(this);
+    this.state = {
+      identifier: identifier !== undefined ? identifier : uuid.v4()
     };
-    return _this;
   }
 
-  _createClass(Graph, [{
-    key: "componentDidMount",
-    value: function componentDidMount() {
-      this.edges = new _vis2.default.DataSet();
-      this.edges.add(this.props.graph.edges);
-      this.nodes = new _vis2.default.DataSet();
-      this.nodes.add(this.props.graph.nodes);
-      this.updateGraph();
+  componentDidMount() {
+    this.edges = new vis.DataSet();
+    this.edges.add(this.props.graph.edges);
+    this.nodes = new vis.DataSet();
+    this.nodes.add(this.props.graph.nodes);
+    this.updateGraph();
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    let nodesChange = !isEqual(this.props.graph.nodes, nextProps.graph.nodes);
+    let edgesChange = !isEqual(this.props.graph.edges, nextProps.graph.edges);
+    let optionsChange = !isEqual(this.props.options, nextProps.options);
+    let eventsChange = !isEqual(this.props.events, nextProps.events);
+
+    if (nodesChange) {
+      const idIsEqual = (n1, n2) => n1.id === n2.id;
+      const nodesRemoved = differenceWith(this.props.graph.nodes, nextProps.graph.nodes, idIsEqual);
+      const nodesAdded = differenceWith(nextProps.graph.nodes, this.props.graph.nodes, idIsEqual);
+      const nodesChanged = differenceWith(
+        differenceWith(nextProps.graph.nodes, this.props.graph.nodes, isEqual),
+        nodesAdded
+      );
+      this.patchNodes({ nodesRemoved, nodesAdded, nodesChanged });
     }
-  }, {
-    key: "shouldComponentUpdate",
-    value: function shouldComponentUpdate(nextProps, nextState) {
-      var nodesChange = !(0, _isEqual2.default)(this.props.graph.nodes, nextProps.graph.nodes);
-      var edgesChange = !(0, _isEqual2.default)(this.props.graph.edges, nextProps.graph.edges);
-      var optionsChange = !(0, _isEqual2.default)(this.props.options, nextProps.options);
-      var eventsChange = !(0, _isEqual2.default)(this.props.events, nextProps.events);
 
-      if (nodesChange) {
-        var idIsEqual = function idIsEqual(n1, n2) {
-          return n1.id === n2.id;
-        };
-        var nodesRemoved = (0, _differenceWith2.default)(this.props.graph.nodes, nextProps.graph.nodes, idIsEqual);
-        var nodesAdded = (0, _differenceWith2.default)(nextProps.graph.nodes, this.props.graph.nodes, idIsEqual);
-        var nodesChanged = (0, _differenceWith2.default)((0, _differenceWith2.default)(nextProps.graph.nodes, this.props.graph.nodes, _isEqual2.default), nodesAdded);
-        this.patchNodes({ nodesRemoved: nodesRemoved, nodesAdded: nodesAdded, nodesChanged: nodesChanged });
-      }
+    if (edgesChange) {
+      const edgesRemoved = differenceWith(this.props.graph.edges, nextProps.graph.edges, isEqual);
+      const edgesAdded = differenceWith(nextProps.graph.edges, this.props.graph.edges, isEqual);
+      const edgesChanged = differenceWith(
+        differenceWith(nextProps.graph.edges, this.props.graph.edges, isEqual),
+        edgesAdded
+      );
+      this.patchEdges({ edgesRemoved, edgesAdded , edgesChanged });
+    }
 
-      if (edgesChange) {
-        var edgesRemoved = (0, _differenceWith2.default)(this.props.graph.edges, nextProps.graph.edges, _isEqual2.default);
-        var edgesAdded = (0, _differenceWith2.default)(nextProps.graph.edges, this.props.graph.edges, _isEqual2.default);
-        var edgesChanged = (0, _differenceWith2.default)((0, _differenceWith2.default)(nextProps.graph.edges, this.props.graph.edges, _isEqual2.default), edgesAdded);
-        this.patchEdges({ edgesRemoved: edgesRemoved, edgesAdded: edgesAdded, edgesChanged : edgesChanged });
-      }
+    if (optionsChange) {
+      this.Network.setOptions(nextProps.options);
+    }
 
-      if (optionsChange) {
-        this.Network.setOptions(nextProps.options);
-      }
+    if (eventsChange) {
+      let events = this.props.events || {};
+      for (let eventName of Object.keys(events)) this.Network.off(eventName, events[eventName]);
 
-      if (eventsChange) {
-        var events = this.props.events || {};
-        var _iteratorNormalCompletion = true;
-        var _didIteratorError = false;
-        var _iteratorError = undefined;
+      events = nextProps.events || {};
+      for (let eventName of Object.keys(events)) this.Network.on(eventName, events[eventName]);
+    }
 
-        try {
-          for (var _iterator = Object.keys(events)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-            var eventName = _step.value;
-            this.Network.off(eventName, events[eventName]);
-          }
-        } catch (err) {
-          _didIteratorError = true;
-          _iteratorError = err;
-        } finally {
-          try {
-            if (!_iteratorNormalCompletion && _iterator.return) {
-              _iterator.return();
-            }
-          } finally {
-            if (_didIteratorError) {
-              throw _iteratorError;
-            }
-          }
-        }
+    return false;
+  }
 
-        events = nextProps.events || {};
-        var _iteratorNormalCompletion2 = true;
-        var _didIteratorError2 = false;
-        var _iteratorError2 = undefined;
+  componentDidUpdate() {
+    this.updateGraph();
+  }
 
-        try {
-          for (var _iterator2 = Object.keys(events)[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-            var _eventName = _step2.value;
-            this.Network.on(_eventName, events[_eventName]);
-          }
-        } catch (err) {
-          _didIteratorError2 = true;
-          _iteratorError2 = err;
-        } finally {
-          try {
-            if (!_iteratorNormalCompletion2 && _iterator2.return) {
-              _iterator2.return();
-            }
-          } finally {
-            if (_didIteratorError2) {
-              throw _iteratorError2;
-            }
+  patchEdges({ edgesRemoved, edgesAdded }) {
+    this.edges.remove(edgesRemoved);
+    this.edges.add(edgesAdded);
+    this.edges.update(edgesChanged);
+  }
+
+  patchNodes({ nodesRemoved, nodesAdded, nodesChanged }) {
+    this.nodes.remove(nodesRemoved);
+    this.nodes.add(nodesAdded);
+    this.nodes.update(nodesChanged);
+  }
+
+  updateGraph() {
+    let container = document.getElementById(this.state.identifier);
+    let defaultOptions = {
+      physics: {
+        stabilization: false
+      },
+      autoResize: false,
+      edges: {
+        smooth: false,
+        color: "#000000",
+        width: 0.5,
+        arrows: {
+          to: {
+            enabled: true,
+            scaleFactor: 0.5
           }
         }
       }
+    };
 
-      return false;
-    }
-  }, {
-    key: "componentDidUpdate",
-    value: function componentDidUpdate() {
-      this.updateGraph();
-    }
-  }, {
-    key: "patchEdges",
-    value: function patchEdges(_ref) {
-      var edgesRemoved = _ref.edgesRemoved,
-          edgesAdded = _ref.edgesAdded;
-          edgesChanged = _ref.edgesChanged;
+    // merge user provied options with our default ones
+    let options = defaultsDeep(defaultOptions, this.props.options);
 
-      this.edges.remove(edgesRemoved);
-      this.edges.add(edgesAdded);
-      this.edges.update(edgesChanged);
-    }
-  }, {
-    key: "patchNodes",
-    value: function patchNodes(_ref2) {
-      var nodesRemoved = _ref2.nodesRemoved,
-          nodesAdded = _ref2.nodesAdded,
-          nodesChanged = _ref2.nodesChanged;
-
-      this.nodes.remove(nodesRemoved);
-      this.nodes.add(nodesAdded);
-      this.nodes.update(nodesChanged);
-    }
-  }, {
-    key: "updateGraph",
-    value: function updateGraph() {
-      var container = document.getElementById(this.state.identifier);
-      var defaultOptions = {
-        physics: {
-          stabilization: false
-        },
-        autoResize: false,
-        edges: {
-          smooth: false,
-          color: "#000000",
-          width: 0.5,
-          arrows: {
-            to: {
-              enabled: true,
-              scaleFactor: 0.5
-            }
-          }
-        }
-      };
-
-      // merge user provied options with our default ones
-      var options = (0, _defaultsDeep2.default)(defaultOptions, this.props.options);
-
-      this.Network = new _vis2.default.Network(container, Object.assign({}, this.props.graph, {
+    this.Network = new vis.Network(
+      container,
+      Object.assign({}, this.props.graph, {
         edges: this.edges,
         nodes: this.nodes
-      }), options);
+      }),
+      options
+    );
 
-      if (this.props.getNetwork) {
-        this.props.getNetwork(this.Network);
-      }
-
-      if (this.props.getNodes) {
-        this.props.getNodes(this.nodes);
-      }
-
-      if (this.props.getEdges) {
-        this.props.getEdges(this.edges);
-      }
-
-      // Add user provied events to network
-      var events = this.props.events || {};
-      var _iteratorNormalCompletion3 = true;
-      var _didIteratorError3 = false;
-      var _iteratorError3 = undefined;
-
-      try {
-        for (var _iterator3 = Object.keys(events)[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
-          var eventName = _step3.value;
-
-          this.Network.on(eventName, events[eventName]);
-        }
-      } catch (err) {
-        _didIteratorError3 = true;
-        _iteratorError3 = err;
-      } finally {
-        try {
-          if (!_iteratorNormalCompletion3 && _iterator3.return) {
-            _iterator3.return();
-          }
-        } finally {
-          if (_didIteratorError3) {
-            throw _iteratorError3;
-          }
-        }
-      }
+    if (this.props.getNetwork) {
+      this.props.getNetwork(this.Network);
     }
-  }, {
-    key: "render",
-    value: function render() {
-      var identifier = this.state.identifier;
-      var style = this.props.style;
 
-      return _react2.default.createElement("div", {
+    if (this.props.getNodes) {
+      this.props.getNodes(this.nodes);
+    }
+
+    if (this.props.getEdges) {
+      this.props.getEdges(this.edges);
+    }
+      
+    // Add user provied events to network
+    let events = this.props.events || {};
+    for (let eventName of Object.keys(events)) {
+      this.Network.on(eventName, events[eventName]);
+    }
+  }
+
+  render() {
+    const { identifier } = this.state;
+    const { style } = this.props;
+    return React.createElement(
+      "div",
+      {
         id: identifier,
-        style: style
-      }, identifier);
-    }
-  }]);
-
-  return Graph;
-}(_react.Component);
+        style
+      },
+      identifier
+    );
+  }
+}
 
 Graph.defaultProps = {
   graph: {},
   style: { width: "100%", height: "100%" }
 };
 Graph.propTypes = {
-  graph: _propTypes2.default.object,
-  style: _propTypes2.default.object,
-  getNetwork: _propTypes2.default.func,
-  getNodes: _propTypes2.default.func,
-  getEdges: _propTypes2.default.func,
+  graph: PropTypes.object,
+  style: PropTypes.object,
+  getNetwork: PropTypes.func,
+  getNodes: PropTypes.func,
+  getEdges: PropTyes.func,  
 };
 
-exports.default = Graph;
+export default Graph;

--- a/src/index.js
+++ b/src/index.js
@@ -1,152 +1,278 @@
-import React, { Component } from "react";
-import defaultsDeep from "lodash/fp/defaultsDeep";
-import isEqual from "lodash/isEqual";
-import differenceWith from "lodash/differenceWith";
-import vis from "vis";
-import uuid from "uuid";
-import PropTypes from "prop-types";
+"use strict";
 
-class Graph extends Component {
-  constructor(props) {
-    super(props);
-    const { identifier } = props;
-    this.updateGraph = this.updateGraph.bind(this);
-    this.state = {
-      identifier: identifier !== undefined ? identifier : uuid.v4()
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require("react");
+
+var _react2 = _interopRequireDefault(_react);
+
+var _defaultsDeep = require("lodash/fp/defaultsDeep");
+
+var _defaultsDeep2 = _interopRequireDefault(_defaultsDeep);
+
+var _isEqual = require("lodash/isEqual");
+
+var _isEqual2 = _interopRequireDefault(_isEqual);
+
+var _differenceWith = require("lodash/differenceWith");
+
+var _differenceWith2 = _interopRequireDefault(_differenceWith);
+
+var _vis = require("vis");
+
+var _vis2 = _interopRequireDefault(_vis);
+
+var _uuid = require("uuid");
+
+var _uuid2 = _interopRequireDefault(_uuid);
+
+var _propTypes = require("prop-types");
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Graph = function (_Component) {
+  _inherits(Graph, _Component);
+
+  function Graph(props) {
+    _classCallCheck(this, Graph);
+
+    var _this = _possibleConstructorReturn(this, (Graph.__proto__ || Object.getPrototypeOf(Graph)).call(this, props));
+
+    var identifier = props.identifier;
+
+    _this.updateGraph = _this.updateGraph.bind(_this);
+    _this.state = {
+      identifier: identifier !== undefined ? identifier : _uuid2.default.v4()
     };
+    return _this;
   }
 
-  componentDidMount() {
-    this.edges = new vis.DataSet();
-    this.edges.add(this.props.graph.edges);
-    this.nodes = new vis.DataSet();
-    this.nodes.add(this.props.graph.nodes);
-    this.updateGraph();
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    let nodesChange = !isEqual(this.props.graph.nodes, nextProps.graph.nodes);
-    let edgesChange = !isEqual(this.props.graph.edges, nextProps.graph.edges);
-    let optionsChange = !isEqual(this.props.options, nextProps.options);
-    let eventsChange = !isEqual(this.props.events, nextProps.events);
-
-    if (nodesChange) {
-      const idIsEqual = (n1, n2) => n1.id === n2.id;
-      const nodesRemoved = differenceWith(this.props.graph.nodes, nextProps.graph.nodes, idIsEqual);
-      const nodesAdded = differenceWith(nextProps.graph.nodes, this.props.graph.nodes, idIsEqual);
-      const nodesChanged = differenceWith(
-        differenceWith(nextProps.graph.nodes, this.props.graph.nodes, isEqual),
-        nodesAdded
-      );
-      this.patchNodes({ nodesRemoved, nodesAdded, nodesChanged });
+  _createClass(Graph, [{
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      this.edges = new _vis2.default.DataSet();
+      this.edges.add(this.props.graph.edges);
+      this.nodes = new _vis2.default.DataSet();
+      this.nodes.add(this.props.graph.nodes);
+      this.updateGraph();
     }
+  }, {
+    key: "shouldComponentUpdate",
+    value: function shouldComponentUpdate(nextProps, nextState) {
+      var nodesChange = !(0, _isEqual2.default)(this.props.graph.nodes, nextProps.graph.nodes);
+      var edgesChange = !(0, _isEqual2.default)(this.props.graph.edges, nextProps.graph.edges);
+      var optionsChange = !(0, _isEqual2.default)(this.props.options, nextProps.options);
+      var eventsChange = !(0, _isEqual2.default)(this.props.events, nextProps.events);
 
-    if (edgesChange) {
-      const edgesRemoved = differenceWith(this.props.graph.edges, nextProps.graph.edges, isEqual);
-      const edgesAdded = differenceWith(nextProps.graph.edges, this.props.graph.edges, isEqual);
-      this.patchEdges({ edgesRemoved, edgesAdded });
-    }
+      if (nodesChange) {
+        var idIsEqual = function idIsEqual(n1, n2) {
+          return n1.id === n2.id;
+        };
+        var nodesRemoved = (0, _differenceWith2.default)(this.props.graph.nodes, nextProps.graph.nodes, idIsEqual);
+        var nodesAdded = (0, _differenceWith2.default)(nextProps.graph.nodes, this.props.graph.nodes, idIsEqual);
+        var nodesChanged = (0, _differenceWith2.default)((0, _differenceWith2.default)(nextProps.graph.nodes, this.props.graph.nodes, _isEqual2.default), nodesAdded);
+        this.patchNodes({ nodesRemoved: nodesRemoved, nodesAdded: nodesAdded, nodesChanged: nodesChanged });
+      }
 
-    if (optionsChange) {
-      this.Network.setOptions(nextProps.options);
-    }
+      if (edgesChange) {
+        var edgesRemoved = (0, _differenceWith2.default)(this.props.graph.edges, nextProps.graph.edges, _isEqual2.default);
+        var edgesAdded = (0, _differenceWith2.default)(nextProps.graph.edges, this.props.graph.edges, _isEqual2.default);
+        var edgesChanged = (0, _differenceWith2.default)((0, _differenceWith2.default)(nextProps.graph.edges, this.props.graph.edges, _isEqual2.default), edgesAdded);
+        this.patchEdges({ edgesRemoved: edgesRemoved, edgesAdded: edgesAdded, edgesChanged : edgesChanged });
+      }
 
-    if (eventsChange) {
-      let events = this.props.events || {};
-      for (let eventName of Object.keys(events)) this.Network.off(eventName, events[eventName]);
+      if (optionsChange) {
+        this.Network.setOptions(nextProps.options);
+      }
 
-      events = nextProps.events || {};
-      for (let eventName of Object.keys(events)) this.Network.on(eventName, events[eventName]);
-    }
+      if (eventsChange) {
+        var events = this.props.events || {};
+        var _iteratorNormalCompletion = true;
+        var _didIteratorError = false;
+        var _iteratorError = undefined;
 
-    return false;
-  }
+        try {
+          for (var _iterator = Object.keys(events)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+            var eventName = _step.value;
+            this.Network.off(eventName, events[eventName]);
+          }
+        } catch (err) {
+          _didIteratorError = true;
+          _iteratorError = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion && _iterator.return) {
+              _iterator.return();
+            }
+          } finally {
+            if (_didIteratorError) {
+              throw _iteratorError;
+            }
+          }
+        }
 
-  componentDidUpdate() {
-    this.updateGraph();
-  }
+        events = nextProps.events || {};
+        var _iteratorNormalCompletion2 = true;
+        var _didIteratorError2 = false;
+        var _iteratorError2 = undefined;
 
-  patchEdges({ edgesRemoved, edgesAdded }) {
-    this.edges.remove(edgesRemoved);
-    this.edges.add(edgesAdded);
-  }
-
-  patchNodes({ nodesRemoved, nodesAdded, nodesChanged }) {
-    this.nodes.remove(nodesRemoved);
-    this.nodes.add(nodesAdded);
-    this.nodes.update(nodesChanged);
-  }
-
-  updateGraph() {
-    let container = document.getElementById(this.state.identifier);
-    let defaultOptions = {
-      physics: {
-        stabilization: false
-      },
-      autoResize: false,
-      edges: {
-        smooth: false,
-        color: "#000000",
-        width: 0.5,
-        arrows: {
-          to: {
-            enabled: true,
-            scaleFactor: 0.5
+        try {
+          for (var _iterator2 = Object.keys(events)[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+            var _eventName = _step2.value;
+            this.Network.on(_eventName, events[_eventName]);
+          }
+        } catch (err) {
+          _didIteratorError2 = true;
+          _iteratorError2 = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion2 && _iterator2.return) {
+              _iterator2.return();
+            }
+          } finally {
+            if (_didIteratorError2) {
+              throw _iteratorError2;
+            }
           }
         }
       }
-    };
 
-    // merge user provied options with our default ones
-    let options = defaultsDeep(defaultOptions, this.props.options);
+      return false;
+    }
+  }, {
+    key: "componentDidUpdate",
+    value: function componentDidUpdate() {
+      this.updateGraph();
+    }
+  }, {
+    key: "patchEdges",
+    value: function patchEdges(_ref) {
+      var edgesRemoved = _ref.edgesRemoved,
+          edgesAdded = _ref.edgesAdded;
+          edgesChanged = _ref.edgesChanged;
 
-    this.Network = new vis.Network(
-      container,
-      Object.assign({}, this.props.graph, {
+      this.edges.remove(edgesRemoved);
+      this.edges.add(edgesAdded);
+      this.edges.update(edgesChanged);
+    }
+  }, {
+    key: "patchNodes",
+    value: function patchNodes(_ref2) {
+      var nodesRemoved = _ref2.nodesRemoved,
+          nodesAdded = _ref2.nodesAdded,
+          nodesChanged = _ref2.nodesChanged;
+
+      this.nodes.remove(nodesRemoved);
+      this.nodes.add(nodesAdded);
+      this.nodes.update(nodesChanged);
+    }
+  }, {
+    key: "updateGraph",
+    value: function updateGraph() {
+      var container = document.getElementById(this.state.identifier);
+      var defaultOptions = {
+        physics: {
+          stabilization: false
+        },
+        autoResize: false,
+        edges: {
+          smooth: false,
+          color: "#000000",
+          width: 0.5,
+          arrows: {
+            to: {
+              enabled: true,
+              scaleFactor: 0.5
+            }
+          }
+        }
+      };
+
+      // merge user provied options with our default ones
+      var options = (0, _defaultsDeep2.default)(defaultOptions, this.props.options);
+
+      this.Network = new _vis2.default.Network(container, Object.assign({}, this.props.graph, {
         edges: this.edges,
         nodes: this.nodes
-      }),
-      options
-    );
+      }), options);
 
-    if (this.props.getNetwork) {
-      this.props.getNetwork(this.Network);
+      if (this.props.getNetwork) {
+        this.props.getNetwork(this.Network);
+      }
+
+      if (this.props.getNodes) {
+        this.props.getNodes(this.nodes);
+      }
+
+      if (this.props.getEdges) {
+        this.props.getEdges(this.edges);
+      }
+
+      // Add user provied events to network
+      var events = this.props.events || {};
+      var _iteratorNormalCompletion3 = true;
+      var _didIteratorError3 = false;
+      var _iteratorError3 = undefined;
+
+      try {
+        for (var _iterator3 = Object.keys(events)[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+          var eventName = _step3.value;
+
+          this.Network.on(eventName, events[eventName]);
+        }
+      } catch (err) {
+        _didIteratorError3 = true;
+        _iteratorError3 = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion3 && _iterator3.return) {
+            _iterator3.return();
+          }
+        } finally {
+          if (_didIteratorError3) {
+            throw _iteratorError3;
+          }
+        }
+      }
     }
+  }, {
+    key: "render",
+    value: function render() {
+      var identifier = this.state.identifier;
+      var style = this.props.style;
 
-    if (this.props.getNodes) {
-      this.props.getNodes(this.nodes);
-    }
-
-    // Add user provied events to network
-    let events = this.props.events || {};
-    for (let eventName of Object.keys(events)) {
-      this.Network.on(eventName, events[eventName]);
-    }
-  }
-
-  render() {
-    const { identifier } = this.state;
-    const { style } = this.props;
-    return React.createElement(
-      "div",
-      {
+      return _react2.default.createElement("div", {
         id: identifier,
-        style
-      },
-      identifier
-    );
-  }
-}
+        style: style
+      }, identifier);
+    }
+  }]);
+
+  return Graph;
+}(_react.Component);
 
 Graph.defaultProps = {
   graph: {},
   style: { width: "100%", height: "100%" }
 };
 Graph.propTypes = {
-  graph: PropTypes.object,
-  style: PropTypes.object,
-  getNetwork: PropTypes.func,
-  getNodes: PropTypes.func
+  graph: _propTypes2.default.object,
+  style: _propTypes2.default.object,
+  getNetwork: _propTypes2.default.func,
+  getNodes: _propTypes2.default.func,
+  getEdges: _propTypes2.default.func,
 };
 
-export default Graph;
+exports.default = Graph;


### PR DESCRIPTION
You can now use the getEdges option to access the edges dataset in the parent component. Similar to [#32](https://github.com/crubier/react-graph-vis/pull/32) and [#15](https://github.com/crubier/react-graph-vis/pull/15) but with edges.

**Usage:**

In parent constructor:
`this.setEdges = this.setEdges.bind(this);`

Add this field to your state in constructor:
`edges : null, //another Vis.js Dataset`

Add function:
`setEdges(edges) {
    this.setState({edges : edges});
  }`

Finally, upon initialization, pass in parameter:
           

```
<Graph graph={this.props.graph}
          options={options}
          events={events}
          style={{ height: '640px', opacity: 1 }}
          getNetwork={this.setNetworkInstance}
          getNodes={this.setNodes}
          getEdges={this.setEdges} //similar to getNodes
        />
```

You can now access the edges dataset in the parent component, a la 
`var modify_edge = this.state.edges.get(id);`

where _id_ is an edge ID.

@crubier, please review and see if I made any mistakes in the code.