### PR TITLE
use official vis-network module

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "uuid": "^2.0.1",
-    "visjs-network": "^4.23.3"
+    "vis-network": "^5.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "uuid": "^2.0.1",
-    "vis-network": "^5.0.0"
+    "vis-network": "^5.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",


### PR DESCRIPTION
`almende/vis` is now maintained by the community: www.visjs.org
I would recommend switching to the official successor [vis-network](https://github.com/visjs/vis-network)

fixes #66 
alternative to #67