### PR TITLE
Modify how to refer to container for test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ class Graph extends Component {
         differenceWith(nextProps.graph.edges, this.props.graph.edges, isEqual),
         edgesAdded
       );
-      this.patchEdges({ edgesRemoved, edgesAdded , edgesChanged });
+      this.patchEdges({ edgesRemoved, edgesAdded, edgesChanged });
     }
 
     if (optionsChange) {
@@ -83,7 +83,7 @@ class Graph extends Component {
   }
 
   updateGraph() {
-    let container = document.getElementById(this.state.identifier);
+    this.container = React.createRef();
     let defaultOptions = {
       physics: {
         stabilization: false
@@ -106,7 +106,7 @@ class Graph extends Component {
     let options = defaultsDeep(defaultOptions, this.props.options);
 
     this.Network = new vis.Network(
-      container,
+      this.container.current,
       Object.assign({}, this.props.graph, {
         edges: this.edges,
         nodes: this.nodes
@@ -140,6 +140,7 @@ class Graph extends Component {
       "div",
       {
         id: identifier,
+        ref: this.container,
         style
       },
       identifier


### PR DESCRIPTION
# Summary
As mentioned at https://github.com/crubier/react-graph-vis/issues/57, It seems that test with Jest fails because of how to refer to container.

I've changed codes by following issue above. Please check this PR. It's subtle change.