### PR TITLE
Update vis-network dependency to v9

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,9 +22,9 @@ var _differenceWith = require("lodash/differenceWith");
 
 var _differenceWith2 = _interopRequireDefault(_differenceWith);
 
-var _visNetwork = require("vis-network");
+var _visData = require("vis-data");
 
-var _visNetwork2 = _interopRequireDefault(_visNetwork);
+var _visNetwork = require("vis-network");
 
 var _uuid = require("uuid");
 
@@ -63,9 +63,9 @@ var Graph = function (_Component) {
   _createClass(Graph, [{
     key: "componentDidMount",
     value: function componentDidMount() {
-      this.edges = new _visNetwork2.default.DataSet();
+      this.edges = new _visData.DataSet();
       this.edges.add(this.props.graph.edges);
-      this.nodes = new _visNetwork2.default.DataSet();
+      this.nodes = new _visData.DataSet();
       this.nodes.add(this.props.graph.nodes);
       this.updateGraph();
     }
@@ -203,7 +203,7 @@ var Graph = function (_Component) {
       // merge user provied options with our default ones
       var options = (0, _defaultsDeep2.default)(defaultOptions, this.props.options);
 
-      this.Network = new _visNetwork2.default.Network(this.container.current, Object.assign({}, this.props.graph, {
+      this.Network = new _visNetwork.Network(this.container.current, Object.assign({}, this.props.graph, {
         edges: this.edges,
         nodes: this.nodes
       }), options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,9 @@
 {
   "name": "react-graph-vis",
-  "version": "1.0.2",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@egjs/hammerjs": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.15.tgz",
-      "integrity": "sha512-BysW5KdNiJ1Qq4JRILaX/Lx2eJGyVPsFSwKA3aJbY+SKv57lS5ZFbEdlgj5shfYPLeJGEnK1WjfleDT+y4s1aQ==",
-      "requires": {
-        "@types/hammerjs": "^2.0.36"
-      }
-    },
-    "@types/hammerjs": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
-      "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ=="
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -90,7 +77,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "async-each": {
       "version": "1.0.1",
@@ -811,6 +799,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
+      "optional": true,
       "requires": {
         "inherits": "~2.0.0"
       }
@@ -907,11 +896,6 @@
       "requires": {
         "graceful-readlink": ">= 1.0.0"
       }
-    },
-    "component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1231,7 +1215,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "boom": {
           "version": "2.10.1",
@@ -1248,6 +1233,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1302,6 +1288,7 @@
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -1320,7 +1307,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1360,7 +1348,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -1380,7 +1369,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
           "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -1405,13 +1395,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fstream": {
           "version": "1.0.12",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
           "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -1454,6 +1446,7 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -1537,6 +1530,7 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -1546,7 +1540,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -1616,13 +1611,15 @@
           "version": "1.25.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
           "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.13",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
           "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.25.0"
           }
@@ -1632,6 +1629,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.0.0"
           }
@@ -1648,6 +1646,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1726,6 +1725,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1734,7 +1734,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "pinkie": {
           "version": "2.0.4",
@@ -1839,6 +1840,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -1879,6 +1881,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2013,7 +2016,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2022,6 +2026,7 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
       "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -2089,6 +2094,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -2174,7 +2180,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
       "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-dotfile": {
       "version": "1.0.2",
@@ -2204,7 +2211,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -2220,6 +2228,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -2266,13 +2275,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -2283,7 +2294,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "isobject": {
       "version": "2.1.0",
@@ -2313,7 +2325,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "jsesc": {
       "version": "1.3.0",
@@ -2334,16 +2347,12 @@
       "dev": true,
       "optional": true
     },
-    "keycharm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.2.0.tgz",
-      "integrity": "sha1-+m6i5DuQpoAohD0n8gddNajD5vk="
-    },
     "kind-of": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
       "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.0.2"
       }
@@ -2413,11 +2422,6 @@
       "requires": {
         "minimist": "0.0.8"
       }
-    },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "nan": {
       "version": "2.5.1",
@@ -2660,7 +2664,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -2683,6 +2688,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "glob": "^7.1.3"
       },
@@ -2692,6 +2698,7 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
           "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -2706,6 +2713,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2716,7 +2724,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -2803,16 +2812,12 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
       "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "block-stream": "*",
         "fstream": "^1.0.12",
         "inherits": "2"
       }
-    },
-    "timsort": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
     "to-fast-properties": {
       "version": "1.0.2",
@@ -2834,7 +2839,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "ua-parser-js": {
       "version": "0.7.14",
@@ -2869,40 +2875,14 @@
       }
     },
     "vis-data": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-6.2.0.tgz",
-      "integrity": "sha512-qvXxun6epiKNbj98iFGFRPXFo474f4MoFbHR+XVmF6zw78tqLlvsDSr42lm9Dz30FdHnAdwAUL3eDTacU9pY8w==",
-      "requires": {
-        "vis-util": "^1.1.0"
-      }
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.1.2.tgz",
+      "integrity": "sha512-RPSegFxEcnp3HUEJSzhS2vBdbJ2PSsrYYuhRlpHp2frO/MfRtTYbIkkLZmPkA/Sg3pPfBlR235gcoKbtdm4mbw=="
     },
     "vis-network": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-5.2.5.tgz",
-      "integrity": "sha512-H5TD378jOgOC9zVxnvkkT6J6q6CM7FOW2LEHDu1ixnkZMioNdVZ/0pi4NfpigZLYHA0EOa91SyAXDmuSICER2w==",
-      "requires": {
-        "@egjs/hammerjs": "^2.0.15",
-        "component-emitter": "^1.3.0",
-        "keycharm": "^0.2.0",
-        "moment": "^2.24.0",
-        "timsort": "^0.3.0",
-        "vis-data": "^6.1.1",
-        "vis-util": "^1.1.6"
-      }
-    },
-    "vis-util": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-1.1.6.tgz",
-      "integrity": "sha512-SKONvwoWQ48soeuApw8iSV8U3Hs/jJN9W1eTEvRvqeTroCGZcZXI9XVrN8+nZGj3XGXBx4vk621YjfewtNg1nQ==",
-      "requires": {
-        "moment": "^2.24.0",
-        "vis-uuid": "^1.1.3"
-      }
-    },
-    "vis-uuid": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/vis-uuid/-/vis-uuid-1.1.3.tgz",
-      "integrity": "sha512-2B6XdY1bkzbUh+TugmnAaFa61KO9R5pzBzIuFIm8a9FrkbxIdSmQXV+FbfkL8QunkQV/bT0JDLQ2puqCS2+0Og=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-9.0.0.tgz",
+      "integrity": "sha512-g/rSWlYQc672O7IU73d8X2sNaoM67uvzdQo2kOD/nXoaYQBNMiIJVF2t6bl9L2S+SRIHkz2+gXafQ+1rqIeUIA=="
     },
     "whatwg-fetch": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-graph-vis",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A react component to render nice graphs using vis.js",
   "main": "lib/index.js",
   "scripts": {
@@ -29,7 +29,8 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.5.10",
     "uuid": "^2.0.1",
-    "vis-network": "^5.1.1"
+    "vis-data": "^7.1.2",
+    "vis-network": "^9.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@ import React, { Component } from "react";
 import defaultsDeep from "lodash/fp/defaultsDeep";
 import isEqual from "lodash/isEqual";
 import differenceWith from "lodash/differenceWith";
-import vis from "vis-network";
+import { DataSet } from "vis-data";
+import { Network } from "vis-network";
 import uuid from "uuid";
 import PropTypes from "prop-types";
 
@@ -18,9 +19,9 @@ class Graph extends Component {
   }
 
   componentDidMount() {
-    this.edges = new vis.DataSet();
+    this.edges = new DataSet();
     this.edges.add(this.props.graph.edges);
-    this.nodes = new vis.DataSet();
+    this.nodes = new DataSet();
     this.nodes.add(this.props.graph.nodes);
     this.updateGraph();
   }
@@ -105,7 +106,7 @@ class Graph extends Component {
     // merge user provied options with our default ones
     let options = defaultsDeep(defaultOptions, this.props.options);
 
-    this.Network = new vis.Network(
+    this.Network = new Network(
       this.container.current,
       Object.assign({}, this.props.graph, {
         edges: this.edges,


### PR DESCRIPTION
We use this library quite extensively, and using the above change didn't break anything. We use quite a range of vis-network events, custom redraws and canvas painting.

Of course I've just tested this against one use case (mine), so maybe we should change the semantic version from 1.0.6 to 2.0.0 for this, as the underlying library probably does have some breaking changes which I haven't spotted. This will guard against users accidentally getting this major update if they've specified something like react-graph-vis: "^1.0.0" in their package.json.