### PR TITLE
Add ability for user supplied/custom datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Due to the imperative nature of vis.js, updating graph properties causes complet
 
 This component takes three vis.js configuration objects as properties:  
 
-- graph: contains two arrays { edges, nodes }
+- graph: contains two arrays or `DataSets`{ edges, nodes }
 - options: normal vis.js options as described [here](http://visjs.org/docs/network/#options)
 - events: an object that has [event name](http://visjs.org/docs/network/#Events) as keys and their callback as values
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,10 +94,18 @@ var Graph = function (_Component) {
   _createClass(Graph, [{
     key: "componentDidMount",
     value: function componentDidMount() {
-      this.edges = new _visData.DataSet();
-      this.edges.add(this.props.graph.edges);
-      this.nodes = new _visData.DataSet();
-      this.nodes.add(this.props.graph.nodes);
+      if (this.props.graph.edges instanceof _visData.DataSet) {
+        this.edges = this.props.graph.edges;
+      } else {
+        this.edges = new _visData.DataSet();
+        this.edges.add(this.props.graph.edges);
+      }
+      if (this.props.graph.edges instanceof _visData.DataSet) {
+        this.nodes = this.props.graph.nodes;
+      } else {
+        this.edges = new _visData.DataSet();
+        this.nodes.add(this.props.graph.nodes);
+      }
       this.updateGraph();
     }
   }, {

--- a/src/index.js
+++ b/src/index.js
@@ -48,10 +48,18 @@ class Graph extends Component {
   }
 
   componentDidMount() {
-    this.edges = new DataSet();
-    this.edges.add(this.props.graph.edges);
-    this.nodes = new DataSet();
-    this.nodes.add(this.props.graph.nodes);
+    if (this.props.graph.edges instanceof DataSet) {
+      this.edges = this.props.graph.edges
+    } else {
+      this.edges = new DataSet();
+      this.edges.add(this.props.graph.edges);
+    }
+    if (this.props.graph.edges instanceof DataSet) {
+      this.nodes = this.props.graph.nodes
+    } else {
+      this.edges = new DataSet();
+      this.nodes.add(this.props.graph.nodes);
+    }
     this.updateGraph();
   }
 


### PR DESCRIPTION
This adds the possibility to use user supplied/custom `DataSets` instead of only arrays for the edges and nodes.

Example:
```
<Graph graph={{ edges: new DataSet(), nodes: new CustomDataSet() }}
              options=.../>
```
or
```
<Graph graph={{ edges: new DataSet(), nodes: [] }}
              options=.../>
```