### PR TITLE
fix: freeze vis-network version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prop-types": "^15.5.10",
     "uuid": "^2.0.1",
     "vis-data": "^7.1.2",
-    "vis-network": "^9.0.0"
+    "vis-network": "9.1.2"
   },
   "devDependencies": {
     "@types/react": "^17.0.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-graph-vis",
+  "name": "react-graph-vis-adk",
   "version": "1.0.7",
   "description": "A react component to render nice graphs using vis.js",
   "main": "lib/index.js",


### PR DESCRIPTION
a few days ago a new version (9.1.7) of the vis-network package was released and it breaks this package
![image](https://github.com/crubier/react-graph-vis/assets/65180969/af3f25a0-2b64-491a-af4c-5d1d5d6e5f88)
[issue](https://github.com/crubier/react-graph-vis/issues/158)
